### PR TITLE
Add job metrics sections for both dirac-3 solver types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 # ignore the DS_Store files which macOS creates
 .DS_store
+.venv

--- a/learn/Developer-resources/Entropy-quantum-optimization/Dirac-3-Developer-Beginner-Guide.ipynb
+++ b/learn/Developer-resources/Entropy-quantum-optimization/Dirac-3-Developer-Beginner-Guide.ipynb
@@ -4,7 +4,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Dirac-3 Developer Beginner Guide\n",
+    "# Dirac-3 Developer Beginner Guide"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Device: Dirac-3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
     "\n",
     "Dirac-3 is the latest addition to QCi's Entropy Quantum Computing (EQC) product line, a unique quantum-hardware approach for tackling hard polynomial optimization problems. Dirac-3 uses non-binary _qudits_ as its unit of quantum information (cf. binary qubits), where each quantum state is represented by $d \\geq 2$ dimensions. Dirac-3 can solve problems with variables beyond binary $(0, 1)$, including non-negative integers and sum-constrained continuous numbers. For further information on qudits, please read through the [Qudit Primer](https://learn.quantumcomputinginc.com/learn/lessons/qudit-basics) to better understand the benefits of high-dimensional programming. To delve deeper into the underlying physics of EQC technology, refer to our paper: [An Open Quantum System for Discrete Optimization](https://arxiv.org/abs/2407.04512).\n",
     "\n",
@@ -14,7 +28,7 @@
     "- [Obtain an API access token](https://quantumcomputinginc.com/learn/tutorials-and-use-cases/quick-start-on-cloud)\n",
     "- [Install qci-client (for Python)](https://quantumcomputinginc.com/learn/tutorials-and-use-cases/quick-start-on-cloud#installation)\n",
     "\n",
-    "The following code block initializes a `QciClient` client (from the [`qci-client`](https://pypi.org/project/qci-client/) Python package imported as `qci_client`) that connects to a Dirac-3 device via QCi's REST API on the cloud (at `url`). As with all of `QciClient`'s API-request methods, the `client`'s `get_allocations` method checks for a non-expired _access_ token from the API, and automatically retrieves/refreshes it when needed (using `api_token` as the _refresh_ token). A successful `get_allocations` call verifies both your authenticated API connectivity and your allocation time (in seconds) for running jobs on Dirac-3. Run this code block successfully (with `api_token` updated to your API token) before attempting to run the subsequent example problems."
+    "Using the Python language, the following code block initializes a `QciClient` client (from the [`qci-client`](https://pypi.org/project/qci-client/) package imported as `qci_client`) that connects to a Dirac-3 device via QCi's REST API on the cloud (at `url`). The `client`'s `get_allocations` method checks for a non-expired _access_ token from the API, and automatically retrieves/refreshes it when needed (using `api_token` as the _refresh_ token). (This is a common pattern across all of `QciClient`'s API-request methods.) A successful `get_allocations` call verifies both your authenticated API connectivity and your allocation time (in seconds) for running jobs on Dirac-3. Run this code block successfully (with `api_token` updated to your API token) before attempting to run the subsequent example problems."
    ]
   },
   {
@@ -23,6 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import datetime\n",
     "import importlib.metadata\n",
     "from pprint import pprint\n",
     "\n",
@@ -38,7 +53,7 @@
     "print(client.get_allocations()[\"allocations\"][\"dirac\"])\n",
     "# This should output something similar to:\n",
     "# qci-client v4.5.0\n",
-    "# {'metered': True, 'seconds': 600}"
+    "# {'metered': True, 'seconds': 600, 'paid': False}"
    ]
   },
   {
@@ -174,8 +189,8 @@
     "    * `num_samples`: The optional number of samples to run for the stochastic solver. The value must be between 1 and 100, with default 1.\n",
     "    * `relaxation_schedule`: A configuration selector that must be in the set $\\{1, 2, 3, 4\\}$, representing four different schedules. The relaxation schedule controls multiple parameters of the quantum machine including the amount of loss, number of feedback loops, the amount of quantum fluctuation, and mean photon number measured. While the first two parameters are fixed, the last two can be further adjusted by users (see below). Lower relaxation schedules are set to larger amount of dissipation in a open quantum system setup, leading to more iterations needed to reach stable states. As a result, the probability of finding an optimal solution can be higher in higher schedules, especially on a competitive energy landscape with the trade-off of longer evolution time. This parameter is optional with a default of 1.\n",
     "    * `num_levels`: An array of positive integers that defines the maximum possible value for each variable. For example, $[2, 2, 3]$ means $x_1$ and $x_2$ take two-level binary values 0 or 1 (qubit) and $x_3$ takes a three-level value 0, 1, or 2 (qudit). If each variable has the same upper bound, then an array with only a single value may be passed. The job will error if the total of `num_levels` over all variables exceeds the device limit (currently 954 on Dirac-3).\n",
-    "    * `mean_photon_number`: An optional advanced configuration parameter that is normally set automatically through the choice of `relaxation_schedule`. A value specified here overrides the default value and should be a real-number value from 0.001 to 1. This parameter is the average number of photons detected over a specific time period which is a time-bin representing a possible value of a variable in Dirac-3. This is a common metric used in photon statistics and quantum optics to approximate the probability of being in the single-photon regime of coherent light. Low mean photon number maintains the quantum superposition effect in high-dimensional time-bin modes of the wavefunction. Notice that extremely low mean photon number to the same order of thermal or electronic noise in single photon detector might affect the solution negatively. [Fox, M. (2006). _Quantum Optics_. Wiley, 75-104., [Pearson, D., Elliott, C. (2004). On the Optimal Mean Photon Number for Quantum Cryptography.](https://arxiv.org/abs/quant-ph/0403065v2), [Mower, J., Zhang, Z., Desjardins, P., Lee, C., Shapiro, J. H., Englund, D. (2013). High-dimensional quantum key distribution using dispersive optics. Phys. Rev. A, 87(6), 062322.](https://link.aps.org/doi/10.1103/PhysRevA.87.062322), [Nguyen, L., Rehain, P., Sua, Y. M., Huang, Y. (2018). Programmable quantum random number generator without postprocessing. Opt. Lett., 43(4), 631-634.](https://opg.optica.org/ol/abstract.cfm?URI=ol-43-4-631)]\n",
-    "    * `quantum_fluctuation_coefficient`: An optional advanced configuration parameter that is normally set automatically through the choice of `relaxation_schedule`. A value specified here overrides the default value and should be an integer value $n \\in \\{1, 2, \\ldots, 50\\}$, which is used to compute the coefficient $\\frac{1}{\\sqrt{n}}$ in the real-valued interval $\\left[ \\frac{1}{\\sqrt{50}}, 1 \\right]$. The inherent randomness of photon arrival time comes from the quantum nature of light giving rise to a fundamental limitation in single photon counting, known as Poisson noise. Dirac-3 takes advantage of this noise arising from quantum fluctuation to gain opportunity to large search space and jump out of local minima. This parameter can be adjusted to allow high or low amount of quantum fluctuation into the open system. A low fluctuation tends to provide a worse solution than a high fluctuation. Notice that, to maintain a good returned solution, this parameter should not reach too high in the same order as the signal photon. [[Bédard, G. (1967). Analysis of Light Fluctuations from Photon Counting Statistics, J. Opt. Soc. Am., 57, 1201-1206.](https://doi.org/10.1364/JOSA.57.001201)]\n",
+    "    * `mean_photon_number`: An optional advanced configuration parameter that is normally set automatically through the choice of `relaxation_schedule`. A value specified here overrides the default value and should be a real-number value from 0.0000667 to 0.0066666. This parameter is the average number of photons detected over a specific time period which is a time-bin representing a possible value of a variable in Dirac-3. This is a common metric used in photon statistics and quantum optics to approximate the probability of being in the single-photon regime of coherent light. Low mean photon number maintains the quantum superposition effect in high-dimensional time-bin modes of the wavefunction. Notice that extremely low mean photon number to the same order of thermal or electronic noise in single photon detector might affect the solution negatively. [Fox, M. (2006). _Quantum Optics_. Wiley, 75-104., [Pearson, D., Elliott, C. (2004). On the Optimal Mean Photon Number for Quantum Cryptography.](https://arxiv.org/abs/quant-ph/0403065v2), [Mower, J., Zhang, Z., Desjardins, P., Lee, C., Shapiro, J. H., Englund, D. (2013). High-dimensional quantum key distribution using dispersive optics. Phys. Rev. A, 87(6), 062322.](https://link.aps.org/doi/10.1103/PhysRevA.87.062322), [Nguyen, L., Rehain, P., Sua, Y. M., Huang, Y. (2018). Programmable quantum random number generator without postprocessing. Opt. Lett., 43(4), 631-634.](https://opg.optica.org/ol/abstract.cfm?URI=ol-43-4-631)]\n",
+    "    * `quantum_fluctuation_coefficient`: An optional advanced configuration parameter that is normally set automatically through the choice of `relaxation_schedule`. A value specified here overrides the default value and should be an integer value $n \\in \\{1, 2, \\ldots, 100\\}$, which is used to compute the coefficient $\\frac{1}{\\sqrt{n}}$ in the real-valued interval $\\left[ \\frac{1}{\\sqrt{100}}, 1 \\right]$. The inherent randomness of photon arrival time comes from the quantum nature of light giving rise to a fundamental limitation in single photon counting, known as Poisson noise. Dirac-3 takes advantage of this noise arising from quantum fluctuation to gain opportunity to large search space and jump out of local minima. This parameter can be adjusted to allow high or low amount of quantum fluctuation into the open system. A low fluctuation tends to provide a worse solution than a high fluctuation. Notice that, to maintain a good returned solution, this parameter should not reach too high in the same order as the signal photon. [[Bédard, G. (1967). Analysis of Light Fluctuations from Photon Counting Statistics, J. Opt. Soc. Am., 57, 1201-1206.](https://doi.org/10.1364/JOSA.57.001201)]\n",
     "\n",
     "* `polynomial_file_id`: The unique identifier for the uploaded polynomial file, retrieved from the file response's `file_id`. This ID links the job to the specific problem data.\n",
     "\n",
@@ -308,8 +323,50 @@
     "- `job_submission`->`problem_config`: contains all the information about the problem that was configured for the job\n",
     "- `job_submission`->`device_config`: contains all the information about the device that was configured for the job\n",
     "- `job_result`->`file_id`: the unique id of the results file that stores the job's result (otherwise has `error` field with error message)\n",
-    "- `job_result`->`device_usage_s`: the amount of \"billable\" time used on the device\n",
+    "- `job_result`->`device_usage_s`: the amount of \"billable\" time used on the device, rounded to the nearest second\n",
     "- `results`: the solutions and corresponding energies (and their corresponding counts) that were found for the job"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Inspecting Job Metrics\n",
+    "\n",
+    "More detailed information about job metrics, including individual sample times, can be retrieved using the client's `get_job_metrics` method. Note that all timestamps and durations are in nanoseconds from the Unix epoch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note that the device is identified as \"dirac-3_qudit\" in these results for the integer solver.\n",
+    "get_job_metrics_response_int_problem = client.get_job_metrics(job_id=job_response_int_problem[\"job_info\"][\"job_id\"])\n",
+    "\n",
+    "# Uncomment the following line to inspect the full set of metrics.\n",
+    "# pprint(get_job_metrics_response_int_problem)\n",
+    "\n",
+    "# Compute the part of the duration of job running on the device in seconds as a difference of timestamps.\n",
+    "start_job_ts_int_problem = get_job_metrics_response_int_problem[\"job_metrics\"][\"time_ns\"][\"device\"][\"dirac-3_qudit\"][\"samples\"][\"start_job_ts\"]\n",
+    "end_job_ts_int_problem = get_job_metrics_response_int_problem[\"job_metrics\"][\"time_ns\"][\"device\"][\"dirac-3_qudit\"][\"samples\"][\"end_job_ts\"]\n",
+    "print(\n",
+    "    \"device-start timestamp, device-end timestamp, duration [s]:\",\n",
+    "    datetime.datetime.fromtimestamp(start_job_ts_int_problem/1e9),  # Convert from nanoseconds to seconds before converting to timestamp.\n",
+    "    datetime.datetime.fromtimestamp(end_job_ts_int_problem/1e9),  # Convert from nanoseconds to seconds before converting to timestamp.\n",
+    "    (end_job_ts_int_problem - start_job_ts_int_problem)/1e9, # Convert from nanoseconds to seconds.\n",
+    ")\n",
+    "\n",
+    "# Convert each sample runtime duration from nanoseconds to seconds.\n",
+    "print(\n",
+    "    \"sample times [s]:\",\n",
+    "    list(map(lambda sample: sample/1e9, get_job_metrics_response_int_problem[\"job_metrics\"][\"time_ns\"][\"device\"][\"dirac-3_qudit\"][\"samples\"][\"runtime\"])),\n",
+    ")\n",
+    "\n",
+    "# This should output something similar to:\n",
+    "# device-start timestamp, device-end timestamp, duration [s]: 2025-06-02 09:00:19.413532 2025-06-02 09:00:21.950028 2.536496067\n",
+    "# sample times [s]: [0.318870217, 0.318995506, 0.299116313, 0.302608073, 0.298885435]"
    ]
   },
   {
@@ -402,8 +459,8 @@
     "    * `relaxation_schedule`: A configuration selector that must be in the set $\\{1, 2, 3, 4\\}$, representing four different schedules. The relaxation schedule controls multiple parameters of the quantum machine including the amount of loss, number of feedback loops, the amount of quantum fluctuation, and mean photon number measured. While the first two parameters are fixed, the last two can be further adjusted by users (see below). Lower relaxation schedules are set to larger amount of dissipation in a open quantum system setup, leading to more iterations needed to reach stable states. As a result, the probability of finding an optimal solution can be higher in higher schedules, especially on a competitive energy landscape with the trade-off of longer evolution time. This parameter is optional with a default of 1.\n",
     "    * `sum_constraint`: A constraint applied to the problem space such that the solution variables must sum to the provided value. Optional value that must be between 1 and 10000, with default 1.\n",
     "    * `solution_precision`: An optional number that specifies the level of precision to apply to the solutions. Omit this when the highest precision continuous solutions are deisired. If specified, then a distillation method is applied to the continuous solutions to reduce them to the submitted `solution_precision`. Note that `sum_constraint` must be divisible by `solution_precision` when the latter is specified.\n",
-    "    * `mean_photon_number`: An optional advanced configuration parameter that is normally set automatically through the choice of `relaxation_schedule`. A value specified here overrides the default value and should be a real-number value from 0.001 to 1. This parameter is the average number of photons detected over a specific time period which is a time-bin representing a possible value of a variable in Dirac-3. This is a common metric used in photon statistics and quantum optics to approximate the probability of being in the single-photon regime of coherent light. Low mean photon number maintains the quantum superposition effect in high-dimensional time-bin modes of the wavefunction. Notice that extremely low mean photon number to the same order of thermal or electronic noise in single photon detector might affect the solution negatively. [Fox, M. (2006). _Quantum Optics_. Wiley, 75-104., [Pearson, D., Elliott, C. (2004). On the Optimal Mean Photon Number for Quantum Cryptography.](https://arxiv.org/abs/quant-ph/0403065v2), [Mower, J., Zhang, Z., Desjardins, P., Lee, C., Shapiro, J. H., Englund, D. (2013). High-dimensional quantum key distribution using dispersive optics. Phys. Rev. A, 87(6), 062322.](https://link.aps.org/doi/10.1103/PhysRevA.87.062322), [Nguyen, L., Rehain, P., Sua, Y. M., Huang, Y. (2018). Programmable quantum random number generator without postprocessing. Opt. Lett., 43(4), 631-634.](https://opg.optica.org/ol/abstract.cfm?URI=ol-43-4-631)]\n",
-    "    * `quantum_fluctuation_coefficient`: An optional advanced configuration parameter that is normally set automatically through the choice of `relaxation_schedule`. A value specified here overrides the default value and should be an integer value $n \\in \\{1, 2, \\ldots, 50\\}$, which is used to compute the coefficient $\\frac{1}{\\sqrt{n}}$ in the real-valued interval $\\left[ \\frac{1}{\\sqrt{50}}, 1 \\right]$. The inherent randomness of photon arrival time comes from the quantum nature of light giving rise to a fundamental limitation in single photon counting, known as Poisson noise. Dirac-3 takes advantage of this noise arising from quantum fluctuation to gain opportunity to large search space and jump out of local minima. This parameter can be adjusted to allow high or low amount of quantum fluctuation into the open system. A low fluctuation tends to provide a worse solution than a high fluctuation. Notice that, to maintain a good returned solution, this parameter should not reach too high in the same order as the signal photon. [[Bédard, G. (1967). Analysis of Light Fluctuations from Photon Counting Statistics, J. Opt. Soc. Am., 57, 1201-1206.](https://doi.org/10.1364/JOSA.57.001201)]\n",
+    "    * `mean_photon_number`: An optional advanced configuration parameter that is normally set automatically through the choice of `relaxation_schedule`. A value specified here overrides the default value and should be a real-number value from from 0.0000667 to 0.0066666. This parameter is the average number of photons detected over a specific time period which is a time-bin representing a possible value of a variable in Dirac-3. This is a common metric used in photon statistics and quantum optics to approximate the probability of being in the single-photon regime of coherent light. Low mean photon number maintains the quantum superposition effect in high-dimensional time-bin modes of the wavefunction. Notice that extremely low mean photon number to the same order of thermal or electronic noise in single photon detector might affect the solution negatively. [Fox, M. (2006). _Quantum Optics_. Wiley, 75-104., [Pearson, D., Elliott, C. (2004). On the Optimal Mean Photon Number for Quantum Cryptography.](https://arxiv.org/abs/quant-ph/0403065v2), [Mower, J., Zhang, Z., Desjardins, P., Lee, C., Shapiro, J. H., Englund, D. (2013). High-dimensional quantum key distribution using dispersive optics. Phys. Rev. A, 87(6), 062322.](https://link.aps.org/doi/10.1103/PhysRevA.87.062322), [Nguyen, L., Rehain, P., Sua, Y. M., Huang, Y. (2018). Programmable quantum random number generator without postprocessing. Opt. Lett., 43(4), 631-634.](https://opg.optica.org/ol/abstract.cfm?URI=ol-43-4-631)]\n",
+    "    * `quantum_fluctuation_coefficient`: An optional advanced configuration parameter that is normally set automatically through the choice of `relaxation_schedule`. A value specified here overrides the default value and should be an integer value $n \\in \\{1, 2, \\ldots, 100\\}$, which is used to compute the coefficient $\\frac{1}{\\sqrt{n}}$ in the real-valued interval $\\left[ \\frac{1}{\\sqrt{100}}, 1 \\right]$. The inherent randomness of photon arrival time comes from the quantum nature of light giving rise to a fundamental limitation in single photon counting, known as Poisson noise. Dirac-3 takes advantage of this noise arising from quantum fluctuation to gain opportunity to large search space and jump out of local minima. This parameter can be adjusted to allow high or low amount of quantum fluctuation into the open system. A low fluctuation tends to provide a worse solution than a high fluctuation. Notice that, to maintain a good returned solution, this parameter should not reach too high in the same order as the signal photon. [[Bédard, G. (1967). Analysis of Light Fluctuations from Photon Counting Statistics, J. Opt. Soc. Am., 57, 1201-1206.](https://doi.org/10.1364/JOSA.57.001201)]\n",
     "\n",
     "* `polynomial_file_id`: The unique identifier for the uploaded polynomial file, retrieved from the file response's `file_id`. This ID links the job to the specific problem data.\n",
     "\n",
@@ -505,11 +562,58 @@
     "#              'solutions': [[0.4174435, 0.5825538, 0, 0]]},\n",
     "#  'status': 'COMPLETED'}"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Inspecting Job Metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note that the device is identified as \"dirac-3_normalized_qudit\" in these results for the continuous solver.\n",
+    "get_job_metrics_response_cts_problem = client.get_job_metrics(job_id=job_response_cts_problem[\"job_info\"][\"job_id\"])\n",
+    "\n",
+    "# Uncomment the following line to inspect the full set of metrics.\n",
+    "pprint(get_job_metrics_response_cts_problem)\n",
+    "\n",
+    "# Compute the part of the duration of job running on the device in seconds as a difference of timestamps.\n",
+    "start_job_ts_cts_problem = get_job_metrics_response_cts_problem[\"job_metrics\"][\"time_ns\"][\"device\"][\"dirac-3_normalized_qudit\"][\"samples\"][\"start_job_ts\"]\n",
+    "end_job_ts_cts_problem = get_job_metrics_response_cts_problem[\"job_metrics\"][\"time_ns\"][\"device\"][\"dirac-3_normalized_qudit\"][\"samples\"][\"end_job_ts\"]\n",
+    "print(\n",
+    "    \"device-start timestamp, device-end timestamp, duration [s]:\",\n",
+    "    datetime.datetime.fromtimestamp(start_job_ts_cts_problem/1e9),  # Convert from nanoseconds to seconds before converting to timestamp.\n",
+    "    datetime.datetime.fromtimestamp(end_job_ts_cts_problem/1e9),  # Convert from nanoseconds to seconds before converting to timestamp.\n",
+    "    (end_job_ts_cts_problem - start_job_ts_cts_problem)/1e9,  # Convert from nanoseconds.\n",
+    ")\n",
+    "\n",
+    "# Convert each sample runtime duration from nanoseconds to seconds.\n",
+    "print(\n",
+    "    \"sample times [s]:\",\n",
+    "    list(map(lambda sample: sample/1e9, get_job_metrics_response_cts_problem[\"job_metrics\"][\"time_ns\"][\"device\"][\"dirac-3_normalized_qudit\"][\"samples\"][\"runtime\"])),\n",
+    ")\n",
+    "\n",
+    "# This should output something similar to:\n",
+    "# device-start timestamp, device-end timestamp, duration [s]: 2025-06-02 09:53:24.566403 2025-06-02 09:53:24.926762 0.360358933\n",
+    "# sample times [s]: [0.103140697]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "debug",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -523,7 +627,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.7"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# ⚡ Pull Request:

## 📄 Description

- Lac requested that we add information about retrieving Dirac job metrics, as a user inquired about individual sample times. Those are added here in the "Dirac-3 Developer Beginner Guide" for both the integer and continuous examples.
- I also updated the `mean_photon_number` and `quantum_fluctuation_coefficient` ranges to latest (in two locations).
- For consistency across pages, I also added the "Device: Dirac-3" callout section.

## 📋 Checklist

- [x] This PR is ready for review. (Add `Ready for review` flag too)

<!--- ## 🎥 Previews  -->
<!--- Provide a list of page paths to preview -->
<!--- This will be autogenerated, no need to add links manually -->
<!--- (but still can add extra links) -->
<!--- DO NOT ADD MULTILINE COMMENT ON THIS SECTION! -->

## 🎥 Previews
- https://data-preview-118--qci-preview.netlify.app/learn/developer-resources/entropy-quantum-optimization/dirac-3-developer-beginner-guide
🔥 Creating Preview... please wait (approximately 5min)